### PR TITLE
Frontmatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+# nodenv
+.node-version

--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@
 [![Build Status](https://travis-ci.org/prosegrinder/annotatedtext-remark.svg?branch=master)](https://travis-ci.org/prosegrinder/annotatedtext-remark)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/3aba5f7e370c4ca6973938158b120b26)](https://www.codacy.com/app/ProseGrinder/annotatedtext-remark?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=prosegrinder/annotatedtext-remark&amp;utm_campaign=Badge_Grade)
 
-A lightweight JavaScript library based on [annotatedtext](https://github.com/prosegrinder/annotatedtext) and
-[remark-parse](https://github.com/remarkjs/remark/tree/master/packages/remark-parse) for
-converting markdown documents into an annotated text format consumable by
-LanguageTool as [AnnotatedText](https://languagetool.org/development/api/org/languagetool/markup/AnnotatedText.html).
+A lightweight JavaScript library based on [annotatedtext](https://github.com/prosegrinder/annotatedtext), [remark-parse](https://github.com/remarkjs/remark/tree/master/packages/remark-parse), and [remark-frontmatter](https://github.com/remarkjs/remark-frontmatter) for converting markdown documents into an annotated text format consumable by LanguageTool as [AnnotatedText](https://languagetool.org/development/api/org/languagetool/markup/AnnotatedText.html).
+
+Front matter is now tagged as markup.
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 var annotatedtext = require("annotatedtext");
 var unified = require("unified");
 var remarkparse = require("remark-parse");
-var frontmatter = require('remark-frontmatter');
+var frontmatter = require("remark-frontmatter");
 
 const defaults = {
   children(node) {
@@ -24,7 +24,7 @@ const defaults = {
 function build(text, options = defaults) {
   const processor = unified()
     .use(remarkparse, options.remarkoptions)
-    .use(frontmatter, ['yaml','toml']);
+    .use(frontmatter, ["yaml","toml"]);
   return annotatedtext.build(text, processor.parse, options);
 }
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var annotatedtext = require("annotatedtext");
 var unified = require("unified");
 var remarkparse = require("remark-parse");
+var frontmatter = require('remark-frontmatter');
 
 const defaults = {
   children(node) {
@@ -22,7 +23,8 @@ const defaults = {
 
 function build(text, options = defaults) {
   const processor = unified()
-    .use(remarkparse, options.remarkoptions);
+    .use(remarkparse, options.remarkoptions)
+    .use(frontmatter, ['yaml','toml']);
   return annotatedtext.build(text, processor.parse, options);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "annotatedtext-remark",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -296,6 +296,14 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
+    "fault": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.3.tgz",
+      "integrity": "sha512-sfFuP4X0hzrbGKjAUNXYvNqsZ5F6ohx/dZ9I0KQud/aiZNwg263r5L9yGB0clvXHCkzXh5W3t7RSHchggYIFmA==",
+      "requires": {
+        "format": "^0.2.2"
+      }
+    },
     "find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -313,6 +321,11 @@
       "requires": {
         "is-buffer": "~2.0.3"
       }
+    },
+    "format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -694,6 +707,15 @@
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
+    },
+    "remark-frontmatter": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-1.3.2.tgz",
+      "integrity": "sha512-2eayxITZ8rezsXdgcXnYB3iLivohm2V/ZT4Ne8uhua6A4pk6GdLE2ZzJnbnINtD1HRLaTdB7RwF9sgUbMptJZA==",
+      "requires": {
+        "fault": "^1.0.1",
+        "xtend": "^4.0.1"
+      }
     },
     "remark-parse": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/prosegrinder/annotatedtext-remark#readme",
   "dependencies": {
     "annotatedtext": "^0.1.1",
+    "remark-frontmatter": "^1.3.2",
     "remark-parse": "^7.0.1",
     "unified": "^8.4.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "annotatedtext-remark",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "A lightweight JavaScript library based on annotatedtext and remark-parse for converting markdown documents into an annotated text format consumable by LanguageTool as AnnotatedText.",
   "main": "index.js",
   "scripts": {

--- a/test/frontmatter-annotatedtext.json
+++ b/test/frontmatter-annotatedtext.json
@@ -1,0 +1,297 @@
+{
+  "annotation": [
+    {
+      "markup": "---\ntitle: frontmatter\nsubject: testing\nspecies: unknown\n---\n# ",
+      "interpretAs": "\n\n\n\n\n",
+      "offset": {
+        "start": 0,
+        "end": 63
+      }
+    },
+    {
+      "text": "ATFB",
+      "offset": {
+        "start": 63,
+        "end": 67
+      }
+    },
+    {
+      "markup": "\n\n",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 67,
+        "end": 69
+      }
+    },
+    {
+      "text": "Annotated Text Format Builder (ATFB) is a JavaScript module for converting various\ntext formats to an annotated text format suitable for processing by the LanguageTool server.",
+      "offset": {
+        "start": 69,
+        "end": 244
+      }
+    },
+    {
+      "markup": "\n\n",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 244,
+        "end": 246
+      }
+    },
+    {
+      "text": "This is just a playground for a proof of concent and may move to a better home if it looks useful.",
+      "offset": {
+        "start": 246,
+        "end": 344
+      }
+    },
+    {
+      "markup": "\n\n## ",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 344,
+        "end": 349
+      }
+    },
+    {
+      "text": "History",
+      "offset": {
+        "start": 349,
+        "end": 356
+      }
+    },
+    {
+      "markup": "\n\n[",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 356,
+        "end": 359
+      }
+    },
+    {
+      "text": "LanguageTool",
+      "offset": {
+        "start": 359,
+        "end": 371
+      }
+    },
+    {
+      "markup": "](https://languagetool.org)",
+      "interpretAs": "",
+      "offset": {
+        "start": 371,
+        "end": 398
+      }
+    },
+    {
+      "text": " is an ",
+      "offset": {
+        "start": 398,
+        "end": 405
+      }
+    },
+    {
+      "markup": "**",
+      "interpretAs": "",
+      "offset": {
+        "start": 405,
+        "end": 407
+      }
+    },
+    {
+      "text": "excellent",
+      "offset": {
+        "start": 407,
+        "end": 416
+      }
+    },
+    {
+      "markup": "**",
+      "interpretAs": "",
+      "offset": {
+        "start": 416,
+        "end": 418
+      }
+    },
+    {
+      "text": " open source spell and grammar checker. It's\nbeing integrated into more and more IDEs so that developers can leverage it alongside their other\ntools. However, LanguageTool's creator has explicitly stated, ",
+      "offset": {
+        "start": 418,
+        "end": 623
+      }
+    },
+    {
+      "markup": "[",
+      "interpretAs": "",
+      "offset": {
+        "start": 623,
+        "end": 624
+      }
+    },
+    {
+      "text": "\"LT only works on plain text, so you'll need to either convert Markdown to plain text first, or tell LT what the markup is.\"",
+      "offset": {
+        "start": 624,
+        "end": 748
+      }
+    },
+    {
+      "markup": "](https://forum.languagetool.org/t/rules-for-markdown/374/2)",
+      "interpretAs": "",
+      "offset": {
+        "start": 748,
+        "end": 808
+      }
+    },
+    {
+      "text": " Pretty clear.",
+      "offset": {
+        "start": 808,
+        "end": 822
+      }
+    },
+    {
+      "markup": "\n\n",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 822,
+        "end": 824
+      }
+    },
+    {
+      "text": "Tdhis makes perfect sense. LanguageTool is meant to parse and analyze natural languages, not computer languages.",
+      "offset": {
+        "start": 824,
+        "end": 936
+      }
+    },
+    {
+      "markup": "\n\n## ",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 936,
+        "end": 941
+      }
+    },
+    {
+      "text": "Goals",
+      "offset": {
+        "start": 941,
+        "end": 946
+      }
+    },
+    {
+      "markup": "\n\n",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 946,
+        "end": 948
+      }
+    },
+    {
+      "text": "So what are the goals here? Glad you asked:",
+      "offset": {
+        "start": 948,
+        "end": 991
+      }
+    },
+    {
+      "markup": "\n\n* ",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 991,
+        "end": 995
+      }
+    },
+    {
+      "text": "Create a simple, lightweight parser in JavaScript.",
+      "offset": {
+        "start": 995,
+        "end": 1045
+      }
+    },
+    {
+      "markup": "\n* ",
+      "interpretAs": "\n",
+      "offset": {
+        "start": 1045,
+        "end": 1048
+      }
+    },
+    {
+      "text": "Be portable across editors that leverage JavaScript in their plugins.",
+      "offset": {
+        "start": 1048,
+        "end": 1117
+      }
+    },
+    {
+      "markup": "\n* ",
+      "interpretAs": "\n",
+      "offset": {
+        "start": 1117,
+        "end": 1120
+      }
+    },
+    {
+      "text": "Map various formatting languages to the simple Annotated Text format described in LanguageTool's API.",
+      "offset": {
+        "start": 1120,
+        "end": 1221
+      }
+    },
+    {
+      "markup": "\n* ",
+      "interpretAs": "\n",
+      "offset": {
+        "start": 1221,
+        "end": 1224
+      }
+    },
+    {
+      "text": "Use this readme as a test document.",
+      "offset": {
+        "start": 1224,
+        "end": 1259
+      }
+    },
+    {
+      "markup": "\n\n",
+      "interpretAs": "\n\n",
+      "offset": {
+        "start": 1259,
+        "end": 1261
+      }
+    },
+    {
+      "text": "Oh, and because we shouldn't assume the text ends with text, here's a link to one of my favorite quotes by Socrates:\n",
+      "offset": {
+        "start": 1261,
+        "end": 1378
+      }
+    },
+    {
+      "markup": "[",
+      "interpretAs": "",
+      "offset": {
+        "start": 1378,
+        "end": 1379
+      }
+    },
+    {
+      "text": "\"I am the wisest man alive, for I know one thing, and that is that I know nothing.\"",
+      "offset": {
+        "start": 1379,
+        "end": 1462
+      }
+    },
+    {
+      "markup": "](https://www.brainyquote.com/quotes/socrates_125872)\n",
+      "interpretAs": "\n",
+      "offset": {
+        "start": 1462,
+        "end": 1516
+      }
+    }
+  ]
+}

--- a/test/frontmatter.md
+++ b/test/frontmatter.md
@@ -1,0 +1,31 @@
+---
+title: frontmatter
+subject: testing
+species: unknown
+---
+# ATFB
+
+Annotated Text Format Builder (ATFB) is a JavaScript module for converting various
+text formats to an annotated text format suitable for processing by the LanguageTool server.
+
+This is just a playground for a proof of concent and may move to a better home if it looks useful.
+
+## History
+
+[LanguageTool](https://languagetool.org) is an **excellent** open source spell and grammar checker. It's
+being integrated into more and more IDEs so that developers can leverage it alongside their other
+tools. However, LanguageTool's creator has explicitly stated, ["LT only works on plain text, so you'll need to either convert Markdown to plain text first, or tell LT what the markup is."](https://forum.languagetool.org/t/rules-for-markdown/374/2) Pretty clear.
+
+Tdhis makes perfect sense. LanguageTool is meant to parse and analyze natural languages, not computer languages.
+
+## Goals
+
+So what are the goals here? Glad you asked:
+
+* Create a simple, lightweight parser in JavaScript.
+* Be portable across editors that leverage JavaScript in their plugins.
+* Map various formatting languages to the simple Annotated Text format described in LanguageTool's API.
+* Use this readme as a test document.
+
+Oh, and because we shouldn't assume the text ends with text, here's a link to one of my favorite quotes by Socrates:
+["I am the wisest man alive, for I know one thing, and that is that I know nothing."](https://www.brainyquote.com/quotes/socrates_125872)

--- a/test/test.js
+++ b/test/test.js
@@ -25,4 +25,25 @@ describe("#build()", function () {
     expect(result).to.equal(expected);
   });
 
+  it("should return the expected annotated text object with frontmatter", function () {
+    const expected = JSON.parse(fs.readFileSync("./test/frontmatter-annotatedtext.json", "utf8"));
+    const text = fs.readFileSync("./test/frontmatter.md", "utf8");
+    const result = builder.build(text);
+    // fs.writeFileSync("./test/frontmatter-annotatedtext.json", JSON.stringify(result));
+    expect(result).to.deep.equal(expected);
+  });
+
+  it("should match the original document exactly with frontmatter", function () {
+    const expected = fs.readFileSync("./test/frontmatter.md", "utf8");
+    const annotatedtext = builder.build(expected);
+    const annotation = annotatedtext.annotation;
+    let result = "";
+    for (let node of annotation) {
+      const text = node.text ? node.text : node.markup;
+      result += text;
+    }
+    expect(result).to.equal(expected);
+  });
+
+
 });


### PR DESCRIPTION
closes #2 

uses [remark-frontmatter](https://github.com/remarkjs/remark-frontmatter) to tag front matter as markup.